### PR TITLE
Copy cookies to URL fetcher's client

### DIFF
--- a/flask_weasyprint/__init__.py
+++ b/flask_weasyprint/__init__.py
@@ -11,8 +11,8 @@
 """
 
 import weasyprint
-from flask import request, current_app
-from werkzeug.test import Client, ClientRedirectError
+from flask import has_request_context, request, current_app
+from werkzeug.test import Client, ClientRedirectError, EnvironBuilder
 from werkzeug.wrappers import Response
 
 try:
@@ -129,6 +129,11 @@ def make_url_fetcher(dispatcher=None,
                 # TODO: double-check this. Apparently Werzeug %-unquotes bytes
                 # but not Unicode URLs. (IRI vs. URI or something.)
                 path = path.encode('utf8')
+            if has_request_context():
+                server_name = EnvironBuilder(
+                    path, base_url=base_url).server_name
+                for (cookie_key, cookie_value) in request.cookies.items():
+                    client.set_cookie(server_name, cookie_key, cookie_value)
             response = client.get(path, base_url=base_url)
             if response.status_code == 200:
                 return dict(


### PR DESCRIPTION
This adds a step in preparing the client used by flask_url_fetcher so that, if there is an existing request context, cookies are copied to the client.

Hopefully this is the approach suggested in issue #5.  I am trying to generate a PDF of a private page which includes images which also require the user to be logged in.  So I can't use the straightforward approach of getting the HTML and passing that to WeasyPrint.

This commit requires Werkzeug version 0.7.  (Changelog entry "Added cookie forging support to the test client", but I don't know why the set_cookie method doesn't seem to appear in the online documentation for Werkzeug.)
