### PR TITLE
Use new WeasyPrint URL fetcher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release new version
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/weasyprint
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install requirements
+        run: python -m pip install flit
+      - name: Build packages
+        run: flit build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+  add-version:
+    name: Add version to GitHub
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install requirements
+        run: sudo apt-get install pandoc
+      - name: Generate content
+        run: |
+          pandoc docs/changelog.rst -f rst -t gfm | csplit - /##/ "{1}" -f .part
+          sed -r "s/^([A-Z].*)\:\$/## \1/" .part01 | sed -r "s/^ *//" | sed -rz "s/([^\n])\n([^\n^-])/\1 \2/g" | tail -n +5 > .body
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: .body

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,4 @@ jobs:
         env:
           DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib
       - name: Check coding style
-        run: python -m flake8
-      - name: Check imports order
-        run: python -m isort . --check --diff
+        run: python -m ruff check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.13']
+        python-version: ['3.14']
         include:
           - os: ubuntu-latest
-            python-version: '3.9'
+            python-version: '3.10'
           - os: ubuntu-latest
-            python-version: 'pypy-3.9'
+            python-version: 'pypy-3.11'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: ['3.14']
         include:
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.11'
           - os: ubuntu-latest
             python-version: 'pypy-3.11'
     steps:

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Flask-WeasyPrint generates PDF files out of your Flask website thanks to
 WeasyPrint.
 
 * Free software: BSD license
-* For Python 3.9+, tested on CPython and PyPy
+* For Python 3.10+, tested on CPython and PyPy
 * Documentation: https://doc.courtbouillon.org/flask-weasyprint
 * Changelog: https://github.com/Kozea/Flask-WeasyPrint/releases
 * Code, issues, tests: https://github.com/Kozea/Flask-WeasyPrint

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Flask-WeasyPrint generates PDF files out of your Flask website thanks to
 WeasyPrint.
 
 * Free software: BSD license
-* For Python 3.10+, tested on CPython and PyPy
+* For Python 3.11+, tested on CPython and PyPy
 * Documentation: https://doc.courtbouillon.org/flask-weasyprint
 * Changelog: https://github.com/Kozea/Flask-WeasyPrint/releases
 * Code, issues, tests: https://github.com/Kozea/Flask-WeasyPrint

--- a/flask_weasyprint/__init__.py
+++ b/flask_weasyprint/__init__.py
@@ -148,7 +148,7 @@ def _wrapper(class_, *args, **kwargs):
     return class_(guess, *args, **kwargs)
 
 
-def HTML(*args, **kwargs):
+def HTML(*args, **kwargs):  # noqa: N802
     """Like :class:`weasyprint.HTML` but:
 
     * :func:`make_url_fetcher` is used to create an ``url_fetcher``
@@ -165,7 +165,7 @@ def HTML(*args, **kwargs):
     return _wrapper(HTML, *args, **kwargs)
 
 
-def CSS(*args, **kwargs):
+def CSS(*args, **kwargs):  # noqa: N802
     from weasyprint import CSS  # lazy loading
     return _wrapper(CSS, *args, **kwargs)
 
@@ -200,5 +200,5 @@ def render_pdf(html, stylesheets=None, download_filename=None,
     pdf = html.write_pdf(stylesheets=stylesheets, **options)
     as_attachment = automatic_download if download_filename else False
     return send_file(
-        BytesIO(pdf), mimetype="application/pdf", as_attachment=as_attachment,
+        BytesIO(pdf), mimetype='application/pdf', as_attachment=as_attachment,
         download_name=download_filename)

--- a/flask_weasyprint/__init__.py
+++ b/flask_weasyprint/__init__.py
@@ -2,9 +2,10 @@
 
 from io import BytesIO
 from urllib.parse import urljoin, urlsplit
+from urllib.request import BaseHandler
 
 from flask import current_app, has_request_context, request, send_file
-from werkzeug.test import Client, ClientRedirectError, EnvironBuilder
+from werkzeug.test import Client, EnvironBuilder
 from werkzeug.wrappers import Response
 
 VERSION = __version__ = '1.1.0'
@@ -73,7 +74,7 @@ def make_flask_url_dispatcher():
 
 
 def make_url_fetcher(dispatcher=None, next_fetcher=True):
-    """Return an function suitable as a ``url_fetcher`` in WeasyPrint.
+    """Return a URL fetcher that handles the Flask app routes internally.
 
     You generally don’t need to call this directly.
 
@@ -92,45 +93,44 @@ def make_url_fetcher(dispatcher=None, next_fetcher=True):
     Typically ``base_url + path`` is equivalent to the passed URL.
 
     """
+    from weasyprint.urls import URLFetcher, URLFetcherResponse  # lazy loading
+
     if next_fetcher is True:
-        from weasyprint import default_url_fetcher  # lazy loading
-        next_fetcher = default_url_fetcher
+        next_fetcher = URLFetcher
 
     if dispatcher is None:
         dispatcher = make_flask_url_dispatcher()
 
-    def flask_url_fetcher(url):
-        redirect_chain = set()
-        while True:
-            result = dispatcher(url)
-            if result is None:
-                return next_fetcher(url)
-            app, base_url, path = result
-            client = Client(app, response_wrapper=Response)
-            if has_request_context() and request.cookies:
-                server_name = EnvironBuilder(
-                    path, base_url=base_url).server_name
-                for cookie_key, cookie_value in request.cookies.items():
-                    client.set_cookie(
-                        cookie_key, cookie_value, domain=server_name)
-            response = client.get(path, base_url=base_url)
-            if response.status_code == 200:
-                return {
-                    'string': response.data, 'mime_type': response.mimetype,
-                    'encoding': 'utf-8', 'redirected_url': url}
-            # The test client can follow redirects, but do it ourselves
-            # to get access to the redirected URL.
-            elif response.status_code in (301, 302, 303, 305, 307, 308):
-                redirect_chain.add(url)
-                url = urljoin(url, response.location)
-                if url in redirect_chain:
-                    raise ClientRedirectError('loop detected')
-            else:
-                raise ValueError(
-                    'Flask-WeasyPrint got HTTP status '
-                    f'{response.status} for {urljoin(base_url, path)}')
+    class FlaskHandler(BaseHandler):
+        def default_open(self, req):
+            url = req.full_url
+            if result := dispatcher(url):
+                app, base_url, path = result
+                client = Client(app, response_wrapper=Response)
+                if has_request_context() and request.cookies:
+                    server_name = EnvironBuilder(path, base_url=base_url).server_name
+                    for cookie_key, cookie_value in request.cookies.items():
+                        client.set_cookie(cookie_key, cookie_value, domain=server_name)
+                response = client.get(path, base_url=base_url)
+                response = URLFetcherResponse(
+                        url, response.data, response.headers, response.status_code)
+                response.msg = ''
+                return response
 
-    return flask_url_fetcher
+    class FlaskFetcher(next_fetcher or URLFetcher):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.add_handler(FlaskHandler())
+
+        def fetch(self, url, headers=None):
+            if dispatcher(url) is None:
+                if next_fetcher:
+                    return super().fetch(url, headers)
+                else:
+                    raise ValueError(f'Unknown Flask app URL: {url}')
+            return URLFetcher.fetch(self, url, headers)
+
+    return FlaskFetcher()
 
 
 def _wrapper(class_, *args, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = {file = 'README.rst', content-type = 'text/x-rst'}
 license = {file = 'LICENSE'}
 dependencies = [
   'flask >=2.3.0',
-  'weasyprint >=53.0',
+  'weasyprint >=68.0',
 ]
 classifiers = [
   'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Donation = 'https://opencollective.com/courtbouillon'
 
 [project.optional-dependencies]
 doc = ['sphinx', 'sphinx_rtd_theme']
-test = ['pytest', 'isort', 'flake8']
+test = ['pytest', 'ruff']
 
 [tool.flit.sdist]
 exclude = ['.*']
@@ -59,6 +59,10 @@ include = ['tests/*', 'flask_weasyprint/*']
 exclude_lines = ['pragma: no cover', 'def __repr__', 'raise NotImplementedError']
 omit = ['.*']
 
-[tool.isort]
-default_section = 'FIRSTPARTY'
-multi_line_output = 4
+[tool.ruff.lint]
+select = ['E', 'W', 'F', 'I', 'N', 'RUF', 'T20', 'PIE', 'PT', 'RSE', 'UP', 'Q']
+ignore = ['RUF001', 'RUF002', 'RUF003']
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = 'single'
+multiline-quotes = 'single'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = 'Make PDF in your Flask app with WeasyPrint'
 keywords = ['html', 'css', 'pdf', 'converter', 'flask', 'weasyprint']
 authors = [{name = 'Simon Sapin', email = 'simon.sapin@exyr.org'}]
 maintainers = [{name = 'CourtBouillon', email = 'contact@courtbouillon.org'}]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 readme = {file = 'README.rst', content-type = 'text/x-rst'}
 license = {file = 'LICENSE'}
 dependencies = [
@@ -24,11 +24,11 @@ classifiers = [
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
   'Programming Language :: Python :: 3 :: Only',
-  'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: 3.14',
   'Programming Language :: Python :: Implementation :: CPython',
   'Programming Language :: Python :: Implementation :: PyPy',
   'Topic :: Internet :: WWW/HTTP :: Dynamic Content',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = 'Make PDF in your Flask app with WeasyPrint'
 keywords = ['html', 'css', 'pdf', 'converter', 'flask', 'weasyprint']
 authors = [{name = 'Simon Sapin', email = 'simon.sapin@exyr.org'}]
 maintainers = [{name = 'CourtBouillon', email = 'contact@courtbouillon.org'}]
-requires-python = '>=3.10'
+requires-python = '>=3.11'
 readme = {file = 'README.rst', content-type = 'text/x-rst'}
 license = {file = 'LICENSE'}
 dependencies = [
@@ -24,7 +24,6 @@ classifiers = [
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
   'Programming Language :: Python :: 3 :: Only',
-  'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,7 +14,7 @@ app = Flask(__name__, static_folder=None)
 
 @app.config.from_object
 class Config:
-    GRAPH_COLORS = ['#0C3795', '#752641', '#E47F00']
+    GRAPH_COLORS = ('#0C3795', '#752641', '#E47F00')
 
 
 @app.route('/')
@@ -115,8 +115,8 @@ def static(filename):
         abort(404)
 
 
-@app.route(u'/Unïĉodé/<stuff>')
-@app.route(u'/foo bar/<stuff>')
+@app.route('/Unïĉodé/<stuff>')
+@app.route('/foo bar/<stuff>')
 def funky_urls(stuff):
     return stuff
 

--- a/tests/test_flask_weasyprint.py
+++ b/tests/test_flask_weasyprint.py
@@ -2,9 +2,10 @@
 
 import pytest
 from flask import Flask, json, jsonify, redirect, request
-from flask_weasyprint import CSS, HTML, make_url_fetcher, render_pdf
 from weasyprint import __version__ as weasyprint_version
 from werkzeug.test import ClientRedirectError
+
+from flask_weasyprint import CSS, HTML, make_url_fetcher, render_pdf
 
 from . import app, document_html
 
@@ -47,13 +48,13 @@ def test_wrappers():
     assert html.write_pdf(stylesheets=[css]).startswith(b'%PDF')
 
 
-@pytest.mark.parametrize('url, filename, automatic, cookie', (
+@pytest.mark.parametrize(('url', 'filename', 'automatic', 'cookie'), [
     ('/foo.pdf', None, None, None),
     ('/foo.pdf', None, None, 'cookie value'),
     ('/foo/', None, True, None),
     ('/foo/', 'bar.pdf', True, None),
     ('/foo/', 'bar.pdf', False, None),
-))
+])
 def test_pdf(url, filename, automatic, cookie):
     if url.endswith('.pdf'):
         client = app.test_client()
@@ -107,7 +108,7 @@ def test_redirects():
     assert result['redirected_url'] == 'http://localhost/d'
     with pytest.raises(ClientRedirectError):
         fetcher('http://localhost/1')
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='404'):
         fetcher('http://localhost/nonexistent')
 
 
@@ -205,12 +206,12 @@ def test_dispatcher():
     assert_dummy('http://a.net/b/')
 
 
-@pytest.mark.parametrize('url', (
+@pytest.mark.parametrize('url', [
     'http://example.net/Unïĉodé/pass !',
     'http://example.net/Unïĉodé/pass !'.encode(),
     'http://example.net/foo%20bar/p%61ss%C2%A0!',
     b'http://example.net/foo%20bar/p%61ss%C2%A0!',
-))
+])
 def test_funky_urls(url):
     with app.test_request_context(base_url='http://example.net/'):
         fetcher = make_url_fetcher()

--- a/tests/test_flask_weasyprint.py
+++ b/tests/test_flask_weasyprint.py
@@ -1,9 +1,11 @@
 """Tests for Flask-WeasyPrint."""
 
+from urllib.error import HTTPError
+
 import pytest
 from flask import Flask, json, jsonify, redirect, request
 from weasyprint import __version__ as weasyprint_version
-from werkzeug.test import ClientRedirectError
+from weasyprint.urls import URLFetcher, URLFetcherResponse
 
 from flask_weasyprint import CSS, HTML, make_url_fetcher, render_pdf
 
@@ -19,15 +21,15 @@ def test_url_fetcher():
     with app.test_request_context(base_url='http://example.org/bar/'):
         fetcher = make_url_fetcher()
 
-    result = fetcher('http://example.org/bar/')
-    assert result['string'].strip().startswith(b'<html>')
-    assert result['mime_type'] == 'text/html'
-    assert result['encoding'] == 'utf-8'
-    assert result['redirected_url'] == 'http://example.org/bar/foo/'
+    response = fetcher('http://example.org/bar/')
+    assert response.read().strip().startswith(b'<html>')
+    assert response.content_type == 'text/html'
+    assert response.charset == 'utf-8'
+    assert response.url == 'http://example.org/bar/foo/'
 
-    result = fetcher('http://example.org/bar/foo/graph?data=1&labels=A')
-    assert result['string'].strip().startswith(b'<svg xmlns=')
-    assert result['mime_type'] == 'image/svg+xml'
+    response = fetcher('http://example.org/bar/foo/graph?data=1&labels=A')
+    assert response.read().strip().startswith(b'<svg xmlns=')
+    assert response.content_type == 'image/svg+xml'
 
     # Also works with a custom dispatcher
     def custom_dispatcher(url_string):
@@ -35,9 +37,9 @@ def test_url_fetcher():
     with app.test_request_context(base_url='http://example.org/bar/'):
         fetcher = make_url_fetcher(dispatcher=custom_dispatcher)
 
-    result = fetcher('test://')
-    assert result['string'].strip().startswith(b'<svg xmlns=')
-    assert result['mime_type'] == 'image/svg+xml'
+    response = fetcher('test://')
+    assert response.read().strip().startswith(b'<svg xmlns=')
+    assert response.content_type == 'image/svg+xml'
 
 
 def test_wrappers():
@@ -103,12 +105,14 @@ def test_redirects():
 
     with app.test_request_context():
         fetcher = make_url_fetcher()
-    result = fetcher('http://localhost/a')
-    assert result['string'] == b'Ok'
-    assert result['redirected_url'] == 'http://localhost/d'
-    with pytest.raises(ClientRedirectError):
+    response = fetcher('http://localhost/a')
+    assert response.read() == b'Ok'
+    assert response.url == 'http://localhost/d'
+    # TODO: keep HTTPError with WeasyPrint > 68.1, see #2686.
+    # with pytest.raises(HTTPError, match='infinite loop'):
+    with pytest.raises((HTTPError, RecursionError)):
         fetcher('http://localhost/1')
-    with pytest.raises(ValueError, match='404'):
+    with pytest.raises(HTTPError, match='404'):
         fetcher('http://localhost/nonexistent')
 
 
@@ -125,21 +129,22 @@ def test_dispatcher():
         app = [subdomain, request.script_root, request.path, query_string]
         return jsonify(app=app)
 
-    def dummy_fetcher(url):
-        return {'string': 'dummy ' + url}
+    class DummyFetcher(URLFetcher):
+        def fetch(self, url, headers=None):
+            return URLFetcherResponse(url, f'dummy {url}')
 
     def assert_app(url, host, script_root, path, query_string=''):
         """The URL was dispatched to the app with these parameters."""
-        assert json.loads(dispatcher(url)['string']) == {
+        assert json.loads(dispatcher(url).read()) == {
             'app': [host, script_root, path, query_string]}
 
     def assert_dummy(url):
         """The URL was not dispatched, the default fetcher was used."""
-        assert dispatcher(url)['string'] == 'dummy ' + url
+        assert dispatcher(url).read() == f'dummy {url}'.encode()
 
     # No SERVER_NAME config, default port
     with app.test_request_context(base_url='http://a.net/b/'):
-        dispatcher = make_url_fetcher(next_fetcher=dummy_fetcher)
+        dispatcher = make_url_fetcher(next_fetcher=DummyFetcher)
     assert_app('http://a.net/b', '', '/b', '/')
     assert_app('http://a.net/b/', '', '/b', '/')
     assert_app('http://a.net/b/', '', '/b', '/')
@@ -153,7 +158,7 @@ def test_dispatcher():
 
     # No SERVER_NAME config, explicit default port
     with app.test_request_context(base_url='http://a.net:80/b/'):
-        dispatcher = make_url_fetcher(next_fetcher=dummy_fetcher)
+        dispatcher = make_url_fetcher(next_fetcher=DummyFetcher)
     assert_app('http://a.net/b', '', '/b', '/')
     assert_app('http://a.net/b/', '', '/b', '/')
     assert_app('http://a.net/b/c/d?e', '', '/b', '/c/d', 'e')
@@ -166,7 +171,7 @@ def test_dispatcher():
 
     # Change the context’s port number
     with app.test_request_context(base_url='http://a.net:8888/b/'):
-        dispatcher = make_url_fetcher(next_fetcher=dummy_fetcher)
+        dispatcher = make_url_fetcher(next_fetcher=DummyFetcher)
     assert_app('http://a.net:8888/b', '', '/b', '/')
     assert_app('http://a.net:8888/b/', '', '/b', '/')
     assert_app('http://a.net:8888/b/cd?e', '', '/b', '/cd', 'e')
@@ -181,7 +186,7 @@ def test_dispatcher():
     # Add a SERVER_NAME config
     app.config['SERVER_NAME'] = 'a.net'
     with app.test_request_context():
-        dispatcher = make_url_fetcher(next_fetcher=dummy_fetcher)
+        dispatcher = make_url_fetcher(next_fetcher=DummyFetcher)
     assert_app('http://a.net', '', '', '/')
     assert_app('http://a.net/', '', '', '/')
     assert_app('http://a.net/b/c/d?e', '', '', '/b/c/d', 'e')
@@ -195,7 +200,7 @@ def test_dispatcher():
     # SERVER_NAME with a port number
     app.config['SERVER_NAME'] = 'a.net:8888'
     with app.test_request_context():
-        dispatcher = make_url_fetcher(next_fetcher=dummy_fetcher)
+        dispatcher = make_url_fetcher(next_fetcher=DummyFetcher)
     assert_app('http://a.net:8888', '', '', '/')
     assert_app('http://a.net:8888/', '', '', '/')
     assert_app('http://a.net:8888/b/c/d?e', '', '', '/b/c/d', 'e')
@@ -208,11 +213,9 @@ def test_dispatcher():
 
 @pytest.mark.parametrize('url', [
     'http://example.net/Unïĉodé/pass !',
-    'http://example.net/Unïĉodé/pass !'.encode(),
     'http://example.net/foo%20bar/p%61ss%C2%A0!',
-    b'http://example.net/foo%20bar/p%61ss%C2%A0!',
 ])
 def test_funky_urls(url):
     with app.test_request_context(base_url='http://example.net/'):
         fetcher = make_url_fetcher()
-    assert fetcher(url)['string'] == 'pass !'.encode()
+    assert fetcher(url).read() == 'pass !'.encode()


### PR DESCRIPTION
This comes with a few minor changes:
- `make_url_fetcher`’s `next_fetcher` should now be a `URLFetcher`,
- bytestring URLs are now forbidden,
- the fetcher’s response is a `URLFetcherResponse`,
- drop Python 3.10 support, as 308 redirects used by recent versions of Flask are supported in 3.11+.